### PR TITLE
Updated UpcomingSchedules to dynamically show schedules

### DIFF
--- a/src/leo-client-app/src/components/SatelliteName.tsx
+++ b/src/leo-client-app/src/components/SatelliteName.tsx
@@ -35,6 +35,11 @@ const SatelliteName = ({ noradId }: Props) => {
     setSelectedNoradId(noradId);
   }, [noradId]);
 
+  // Effect for on load
+  useEffect(() => {
+    fetchData(); // Fetch data initially
+  }, []);
+
   return (
     <Box
       className="material-themedisplaymedium"
@@ -43,7 +48,8 @@ const SatelliteName = ({ noradId }: Props) => {
         textAlign: "left",
         boxSizing: "border-box",
         marginTop: "50px",
-      }}>
+      }}
+    >
       {satelliteName}
     </Box>
   );

--- a/src/leo-client-app/src/components/UpcomingSchedules.tsx
+++ b/src/leo-client-app/src/components/UpcomingSchedules.tsx
@@ -11,6 +11,7 @@ import {
   Stack,
 } from "@mui/material";
 import { BACKEND_URL } from "@/constants/api";
+import axios from "axios";
 
 interface Schedule {
   id: string;
@@ -52,13 +53,29 @@ function formatTimeRange(startTime: string, endTime: string) {
 }
 
 const UpcomingSchedules = ({ noradId }: Props) => {
-  // TODO: Dynamically get satelliteId from somewhere
-  const satelliteId = "655acd63d122507055d3d2ea";
+  const [satelliteId, setSatelliteId] = useState<string>(
+    "655acd63d122507055d3d2ea"
+  );
+
   const [schedules, setSchedules] = useState<Schedule[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [scheduleCommands, setScheduleCommands] = useState<{
     [scheduleId: string]: string[];
   }>({});
+
+  const fetchSatelliteId = (noradId: string) => {
+    return axios
+      .get(`${BACKEND_URL}/satellite/getSatelliteIdByNorad`, {
+        params: { noradId: noradId },
+      })
+      .then((res) => {
+        setSatelliteId(res.data.satellite[0]._id);
+        fetchSchedules(res.data.satellite[0]._id);
+      })
+      .catch((error) => {
+        console.error("Error fetching satellite id:", error);
+      });
+  };
 
   const fetchSchedules = (satelliteId: string) => {
     setIsLoading(true); // Set loading state to true when starting to fetch
@@ -111,8 +128,12 @@ const UpcomingSchedules = ({ noradId }: Props) => {
   };
 
   useEffect(() => {
-    fetchSchedules(satelliteId);
+    fetchSatelliteId(noradId);
   }, [satelliteId]);
+
+  useEffect(() => {
+    fetchSatelliteId(noradId);
+  }, [noradId]);
 
   return (
     <div className="upcomingSchedulesBox">
@@ -137,7 +158,8 @@ const UpcomingSchedules = ({ noradId }: Props) => {
                 flex: "0 0 auto",
               },
               mx: -2,
-            }}>
+            }}
+          >
             {schedules &&
               schedules.map((schedule, index) => (
                 <Grid item key={index}>
@@ -154,7 +176,8 @@ const UpcomingSchedules = ({ noradId }: Props) => {
                       maxHeight: 150,
                       display: "flex",
                       flexDirection: "column",
-                    }}>
+                    }}
+                  >
                     <CardContent>
                       <Stack spacing={0}>
                         <p className="cardTitle">

--- a/src/leo-server-app/src/routes/satellite.ts
+++ b/src/leo-server-app/src/routes/satellite.ts
@@ -324,9 +324,11 @@ router.get("/getSatellite", async (req: any, res: any) => {
 });
 
 router.get("/getSatelliteIdByNorad", async (req: any, res: any) => {
-  const noradId = req.query.noradId;
+  const filter = {
+    noradId: req.query.noradId,
+  };
 
-  const satellite = await SatelliteModel.find({ noradId: noradId });
+  const satellite = await SatelliteModel.find(filter).limit(1).exec();
   res.status(201).json({ message: "Fetched satellite", satellite });
 });
 

--- a/src/leo-server-app/src/routes/satellite.ts
+++ b/src/leo-server-app/src/routes/satellite.ts
@@ -323,4 +323,11 @@ router.get("/getSatellite", async (req: any, res: any) => {
   res.status(201).json({ message: "Fetched satellite", satellite });
 });
 
+router.get("/getSatelliteIdByNorad", async (req: any, res: any) => {
+  const noradId = req.query.noradId;
+
+  const satellite = await SatelliteModel.find({ noradId: noradId });
+  res.status(201).json({ message: "Fetched satellite", satellite });
+});
+
 module.exports = { router, getSatelliteInfo, setTleLines };


### PR DESCRIPTION
![image](https://github.com/LowerEarthOrbiters/Lower_Earth_Orbiters/assets/35006641/3b5fb234-5a58-4155-9683-bb480d779d10)
![image](https://github.com/LowerEarthOrbiters/Lower_Earth_Orbiters/assets/35006641/088e5ab9-10aa-43c9-9788-e7c0edfe545c)
![image](https://github.com/LowerEarthOrbiters/Lower_Earth_Orbiters/assets/35006641/d3ee6e7a-f9a3-45ed-bd6b-cecf03f979a6)

UpcomingSchedules now dynamically shows schedules. Added get getSatelliteIdByNorad endpoint as well